### PR TITLE
Added cursor

### DIFF
--- a/nixos/packages.nix
+++ b/nixos/packages.nix
@@ -120,6 +120,16 @@
 
     lm_sensors
     bc
+
+    (pkgs.appimageTools.wrapType2 {
+      pname = "cursor";
+      version = "0.1.0";
+
+      src = pkgs.fetchurl {
+        url = "https://downloader.cursor.sh/linux/appImage/x64";
+        hash = "sha256-3TJLfrBd+TyFVqommSqs8ncNpDFHZ5v8SGL4b62QYUQ="; # Will need to be changed as they modify their path. 
+      };                                                              # Their url doesn't have version's so this will give error once they update it.
+    })
   ];
 
   fonts.packages = with pkgs; [


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/dd27fb22-8d27-42de-a0b2-799a2a7af4d1)

Their URL sucks, as such when **they change it** to point to the **next version** we will have to r**eplace the hash**. I'll show the error it will give.

![image](https://github.com/user-attachments/assets/e0acafec-d5ce-449c-9de9-6157b852e407)

I modified the hash to be wrong, it will be like this. Honestly this software should just be an extension, but nothing to do. 

Is it even open-source, anyways. I packaged it.  Enjoy!